### PR TITLE
Add Svelte files for completion.

### DIFF
--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -72,6 +72,7 @@ nova.assistants.registerCompletionAssistant("html+erb", new CompletionProvider()
 nova.assistants.registerCompletionAssistant("html+haml", new CompletionProvider());
 nova.assistants.registerCompletionAssistant("php", new CompletionProvider());
 nova.assistants.registerCompletionAssistant("vue", new CompletionProvider());
+nova.assistants.registerCompletionAssistant("svelte", new CompletionProvider());
 nova.assistants.registerCompletionAssistant("js", new CompletionProvider());
 nova.assistants.registerCompletionAssistant("jsx", new CompletionProvider());
 nova.assistants.registerCompletionAssistant("ts", new CompletionProvider());


### PR DESCRIPTION
Btw, is there any good way to offer completion to other template files without manually acknowledging any possible formats in this extension, or leave this as an option to users? Maybe a problem for Panic?

(PS: I just made [Svelte Nova](https://github.com/laosb/SvelteNova) for simple Svelte LSP integration in Nova, feel free to try out)