### PR TITLE
Bypass completions in special VueJS cases

### DIFF
--- a/Scripts/completion_provider.js
+++ b/Scripts/completion_provider.js
@@ -52,10 +52,25 @@ exports.CompletionProvider = class CompletionProvider {
   provideCompletionItems(editor, context) {
     let currentWordRange = FUNCTIONS.getRangeOfCurrentWord(editor, context)
 
+    if (this.bypassSpecialCase(context)) { return }
+
     this._items.forEach(item => {
       item.range = currentWordRange
     })
 
     return this._items
+  }
+  
+  bypassSpecialCase(context) {
+    const rootScope = context.selectors.pop()
+
+    if (rootScope?.matches('vue.html.embedded.script')) {
+      return true
+    }
+    if (rootScope?.matches('vue.html.embedded.style') && !context.line.includes('@apply')) {
+      return true
+    }
+
+    return false
   }
 }


### PR DESCRIPTION
Hi there! I started messing around with this extension in some VueJS projects and I noticed a couple of possible improvements.

This PR basically adds some checks before providing completions. The first one disallow completions in VueJS script block and the second one allow completions in the style block only if the line includes the `@apply` directive.

## Screenshots

### Before

**Script tag before changes**

<img width="559" alt="Schermata 2021-07-05 alle 10 41 06" src="https://user-images.githubusercontent.com/25225746/124443104-b018d500-dd7d-11eb-9f92-b6bbc9c3aac3.png">

**Style tag before changes**

<img width="559" alt="Schermata 2021-07-05 alle 10 41 29" src="https://user-images.githubusercontent.com/25225746/124443274-d3dc1b00-dd7d-11eb-9374-ada7f3478366.png">

### After

**Script tag after changes**

<img width="559" alt="Schermata 2021-07-05 alle 10 41 50" src="https://user-images.githubusercontent.com/25225746/124443312-dc345600-dd7d-11eb-9624-931ac6bddba9.png">

**Style tag after changes**

<img width="559" alt="Schermata 2021-07-05 alle 10 41 55" src="https://user-images.githubusercontent.com/25225746/124444194-a479de00-dd7e-11eb-9188-19a427054469.png">

## Considerations

I'm not sure if blocking completions this way is correct but it works... I'm open to feedback.

This method `bypassSpecialCase` could possibly be used also in other cases apart from Vue. For example when class completions will be available in css files it could be used in the same way to show completions only after `@apply`. I've also tried to implement the same fine tuning for svelte but in that case the scope selectors are the same as html. We should probably ping the maintainer of the extension to solve that...

I hope this will be useful and accepted. In any case thanks for you great work!