### PR TITLE
Toggling TailwindCSS Extension On & Off  Across Different Languages (PHP Ruby ...etc)

### DIFF
--- a/Scripts/completion_provider.js
+++ b/Scripts/completion_provider.js
@@ -105,7 +105,15 @@ exports.CompletionProvider = class CompletionProvider {
       // console.log(context.selectors[1].string)
       // console.log(context.selectors[2].string)
       // console.log(context.selectors[0].matches('html'))
-
+      
+      //Prevent completion in php context
+      if (
+        context.selectors[0].string === 'php.string.single-quoted.delimiter' ||
+        'php.string.double-quoted.delimiter'
+      ) {
+        return true;
+      }
+      
       // Allow completions if context selectors is a HTML class attribute value.
       if (context.selectors[0].matches('html.tag.attribute.class.value.double-quoted')) { return false }
 

--- a/Scripts/completion_provider.js
+++ b/Scripts/completion_provider.js
@@ -10,6 +10,10 @@ exports.CompletionProvider = class CompletionProvider {
     this._items       = []
   }
 
+//on|off switch for the extension
+static _toggle = false
+
+
   async loadCompletionItems() {
     this._definitions.forEach(definitionFile => {
       let twClasses = definitionFile.twClasses(this._config)
@@ -98,8 +102,14 @@ exports.CompletionProvider = class CompletionProvider {
 
     return completionItemKind
   }
-
+  
+  // tailwind.toggle command
+  static toggle() { this._toggle = !this._toggle}
+  
   _preventCompletions(context) {
+    
+    if(CompletionProvider._toggle){ return true }
+    
     if (context.selectors.length > 0) {
       // console.log(context.selectors[0].string)
       // console.log(context.selectors[1].string)

--- a/Scripts/completion_provider.js
+++ b/Scripts/completion_provider.js
@@ -116,13 +116,6 @@ static _toggle = false
       // console.log(context.selectors[2].string)
       // console.log(context.selectors[0].matches('html'))
       
-      //Prevent completion in php context
-      if (
-        context.selectors[0].string === 'php.string.single-quoted.delimiter' ||
-        'php.string.double-quoted.delimiter'
-      ) {
-        return true;
-      }
       
       // Allow completions if context selectors is a HTML class attribute value.
       if (context.selectors[0].matches('html.tag.attribute.class.value.double-quoted')) { return false }

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -121,3 +121,8 @@ nova.commands.register('tailwind.doubleClick', () => {
 nova.commands.register('tailwind.openCategoryDocs', () => {
   nova.openURL(Configuration.TAILWIND_DOCS_URL + FUNCTIONS.camelCaseToLowercaseDash(sidebar.treeView.selection[0].urlName))
 })
+
+// Register the Toggle and modify the CompletionProvider Class
+nova.commands.register('tailwind.toggle', (workspace) => {
+  CompletionProvider.toggle() 
+})

--- a/Scripts/main.js
+++ b/Scripts/main.js
@@ -123,6 +123,6 @@ nova.commands.register('tailwind.openCategoryDocs', () => {
 })
 
 // Register the Toggle and modify the CompletionProvider Class
-nova.commands.register('tailwind.toggle', (workspace) => {
+nova.commands.register('tailwind.toggle', () => {
   CompletionProvider.toggle() 
 })

--- a/extension.json
+++ b/extension.json
@@ -69,5 +69,15 @@
         }
       ]
     }
-  ]
+  ],
+  
+  "commands": {
+      "command-palette": [
+          {
+              "title": "Toggle TailwindCSS",
+              "command": "tailwind.toggle",
+          }
+      ]
+      
+  }
 }


### PR DESCRIPTION
Hi Jason, the extension still suggests tailwind autocompletion in the php context, this should hopefully fix it. I believe there was an issue raised as well with regards to this (#20)