### PR TITLE
Add Astro support

### DIFF
--- a/Scripts/configuration.js
+++ b/Scripts/configuration.js
@@ -23,7 +23,7 @@ exports.Configuration = class Configuration {
     return [
       'html', 'html+erb', 'html+eex', 'haml', 'php', 'blade', 'twig',
       'vue', 'js', 'jsx', 'ts', 'tsx', 'svelte', 'liquid', 'jade', 'pug',
-      'css', 'sass', 'scss'
+      'css', 'sass', 'scss', 'astro'
     ]
   }
 


### PR DESCRIPTION
Hi, just a small tweak to add `.astro` file support to the extension for use with https://astro.build static sites.

Let me know if I've missed anything 🙂