### PR TITLE
Tailwind V3.0 flex-grow/shrink new aliases support

### DIFF
--- a/Definitions/3.0.0/flexbox-and-grid.js
+++ b/Definitions/3.0.0/flexbox-and-grid.js
@@ -105,6 +105,16 @@ exports.twClasses = function twClasses(config) {
       label:         'flex-grow',
       detail:        'flex-grow: 1;',
       documentation: 'Allow a flex item to grow to fill available space.'
+    },
+    {
+      label:         'grow-0',
+      detail:        'flex-grow: 0;',
+      documentation: 'Prevent a flex item from growing.'
+    },
+    {
+      label:         'grow',
+      detail:        'flex-grow: 1;',
+      documentation: 'Allow a flex item to grow to fill available space.'
     }
   ]
 
@@ -118,6 +128,16 @@ exports.twClasses = function twClasses(config) {
     },
     {
       label:         'flex-shrink',
+      detail:        'flex-shrink: 1;',
+      documentation: 'Allow a flex item to shrink if needed.'
+    },
+    {
+      label:         'shrink-0',
+      detail:        'flex-shrink: 0;',
+      documentation: 'Prevent a flex item from shrinking.'
+    },
+    {
+      label:         'shrink',
       detail:        'flex-shrink: 1;',
       documentation: 'Allow a flex item to shrink if needed.'
     }


### PR DESCRIPTION
Hi Jason,

I Just added support for the new grow/shrink class names, here is the link to  [V3.0 Upgrade Guide](https://tailwindcss.com/docs/upgrade-guide#flex-grow-shrink).

Now the upgrade guide suggests the shrink/grow is the preferred way going forward however since the old class names still work, I did not delete them, just added the new ones underneath just in case some folk's muscle memory kicks in and they get upset not seeing the `flex-grow/shrink-*`.

Again whatever you feel is the best way forward for the extension, so feel free to delete the old class names if you think it is appropriate (I personally hate the old ones hence submitting the pull request) 😊

Thanks
Emran